### PR TITLE
correct target_os string is macos, not osx

### DIFF
--- a/vfs/Cargo.toml
+++ b/vfs/Cargo.toml
@@ -20,7 +20,7 @@ slab = "0.4.6"
 tokio = { workspace = true }
 tracing = { workspace = true }
 
-[target.'cfg(any(target_os = "linux", target_os = "osx"))'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
 fuser = "0.11.0"
 libc = "0.2.126"
 

--- a/vfs/src/open_flags.rs
+++ b/vfs/src/open_flags.rs
@@ -52,18 +52,24 @@ impl fmt::Display for OpenFlags {
         write(libc::O_ASYNC, "ASYNC")?;
         write(libc::O_CLOEXEC, "CLOEXEC")?;
         write(libc::O_CREAT, "CREAT")?;
-        write(libc::O_DIRECT, "DIRECT")?;
         write(libc::O_DIRECTORY, "DIRECTORY")?;
         write(libc::O_DSYNC, "DSYNC")?;
         write(libc::O_EXCL, "EXCL")?;
-        write(libc::O_NOATIME, "NOATIME")?;
         write(libc::O_NOCTTY, "NOCTTY")?;
         write(libc::O_NOFOLLOW, "NOFOLLOW")?;
         write(libc::O_NONBLOCK, "NONBLOCK")?;
-        write(libc::O_PATH, "PATH")?;
         write(libc::O_SYNC, "SYNC")?;
-        write(libc::O_TMPFILE, "TMPFILE")?;
         write(libc::O_TRUNC, "TRUNC")?;
+
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd", target_os = "netbsd", target_os = "dragonfly"))]
+        write(libc::O_DIRECT, "DIRECT")?;
+
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        {
+            write(libc::O_NOATIME, "NOATIME")?;
+            write(libc::O_PATH, "PATH")?;
+            write(libc::O_TMPFILE, "TMPFILE")?;
+        }
 
         Ok(())
     }


### PR DESCRIPTION
The build currently fails on macos 12.6.1 for two reasons
- `macos` is incorrectly called `osx` in `Cargo.toml`, causing `libc` and `fuser` not to get installed
- a variety of linux/freebsd/netbsd specific `O_<WHATEVER>` flags are referenced, which are not known in the rust `libc` package on macos

I've corrected this in the way that makes sense to me, so it builds on my mac now, but I have not tested it.