### PR TITLE
Add support for publishing AAR to Sonatype

### DIFF
--- a/bindings/kotlin/build-scripts/publish-module.gradle
+++ b/bindings/kotlin/build-scripts/publish-module.gradle
@@ -1,0 +1,65 @@
+apply plugin: 'maven-publish'
+apply plugin: 'signing'
+
+task androidSourcesJar(type: Jar) {
+    archiveClassifier.set('sources')
+    if (project.plugins.findPlugin("com.android.library")) {
+        from android.sourceSets.main.java.srcDirs
+    }
+}
+
+artifacts {
+    archives androidSourcesJar
+}
+
+group = PUBLISH_GROUP_ID
+version = PUBLISH_VERSION
+
+afterEvaluate {
+    publishing {
+        publications {
+            release(MavenPublication) {
+                // The coordinates of the library, being set from variables that
+                // we'll set up later
+                groupId PUBLISH_GROUP_ID
+                artifactId PUBLISH_ARTIFACT_ID
+                version PUBLISH_VERSION
+
+                // Two artifacts, the `aar` (or `jar`) and the sources
+                artifact androidSourcesJar
+                artifact("$rootDir/build/lib/outputs/aar/lib-release.aar")
+
+                pom {
+                    name = PUBLISH_ARTIFACT_ID
+                    description = 'Library to enable decentralized web requests'
+                    url = 'https://github.com/equalitie/ouisync'
+                    licenses {
+                        license {
+                            name = 'MPL-2.0'
+                            url = 'https://github.com/equalitie/ouisync/blob/master/LICENSE'
+                        }
+                    }
+                    developers {
+                        developer {
+                            name = 'Ouisync Developers'
+                            email = 'ouisync@equalit.ie'
+                        }
+                    }
+
+                    scm {
+                        connection = 'scm:git:github.com/equalitie/ouisync.git'
+                        developerConnection = 'scm:git:ssh://github.com/equalitie/ouisync.git'
+                        url = 'https://github.com/equalitie/ouisync/tree/master'
+                    }
+                }
+            }
+        }
+    }
+}
+
+signing {
+    if (signingKey) {
+        useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
+    }
+    sign publishing.publications
+}

--- a/bindings/kotlin/build-scripts/publish-root.gradle
+++ b/bindings/kotlin/build-scripts/publish-root.gradle
@@ -1,0 +1,20 @@
+// Use system environment variables
+ext["ossrhUsername"] = System.getenv('OSSRH_USERNAME')
+ext["ossrhPassword"] = System.getenv('OSSRH_PASSWORD')
+ext["sonatypeStagingProfileId"] = System.getenv('SONATYPE_STAGING_PROFILE_ID')
+ext["signingKey"] = System.getenv('SIGNING_KEY')
+ext["signingKeyId"] = System.getenv('SIGNING_KEY_ID')
+ext["signingPassword"] = System.getenv('SIGNING_PASSWORD')
+
+// Set up Sonatype repository
+nexusPublishing {
+    repositories {
+        sonatype {
+            stagingProfileId = sonatypeStagingProfileId
+            username = ossrhUsername
+            password = ossrhPassword
+            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+        }
+    }
+}

--- a/bindings/kotlin/build.gradle
+++ b/bindings/kotlin/build.gradle
@@ -17,6 +17,7 @@ buildscript {
 
 plugins {
     id 'com.diffplug.spotless' version '6.21.0'
+    id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
 }
 
 
@@ -46,3 +47,5 @@ tasks.named('clean') {
         delete rootProject.layout.buildDirectory.get()
     }
 }
+
+apply from: "${rootDir}/build-scripts/publish-root.gradle"

--- a/bindings/kotlin/example/build.gradle
+++ b/bindings/kotlin/example/build.gradle
@@ -3,6 +3,12 @@ plugins {
     id 'kotlin-android'
 }
 
+Properties localProperties = new Properties()
+localProperties.load(rootProject.file('local.properties').newDataInputStream())
+def useLocalLib = false
+if (localProperties.containsKey("useLocalLib"))
+    useLocalLib = localProperties.getProperty("useLocalLib").toBoolean()
+
 android {
     compileSdkVersion 34
     namespace 'org.equalitie.ouisync.example'
@@ -38,5 +44,12 @@ dependencies {
     implementation 'androidx.compose.material3:material3'
     implementation "androidx.activity:activity-compose:1.7.2"
 
-    implementation project(':lib')
+    if (useLocalLib) {
+        implementation project(':lib')
+    }
+    else {
+        implementation 'ie.equalit.ouinet:ouisync-omni:0.7.2'
+        implementation 'net.java.dev.jna:jna:5.13.0@aar'
+        implementation 'org.msgpack:msgpack-core:0.9.5'
+    }
 }

--- a/bindings/kotlin/lib/build.gradle
+++ b/bindings/kotlin/lib/build.gradle
@@ -5,8 +5,12 @@ plugins {
     id 'org.mozilla.rust-android-gradle.rust-android' version '0.9.3'
 }
 
+Properties localProperties = new Properties()
+localProperties.load(rootProject.file('local.properties').newDataInputStream())
+def ouisyncVersionName = localProperties.getProperty("versionName")
+
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
     ndkVersion '25.2.9519653'
 
     namespace 'org.equalitie.ouisync'
@@ -21,8 +25,10 @@ android {
     }
 
     defaultConfig {
-        targetSdkVersion 33
+        targetSdkVersion 34
         minSdkVersion 21
+        versionCode 1
+        versionName ouisyncVersionName
     }
 
     compileOptions {
@@ -112,3 +118,15 @@ afterEvaluate {
         }
     }
 }
+
+ext {
+    PUBLISH_GROUP_ID = 'ie.equalit.ouinet'
+    PUBLISH_VERSION = "${ouisyncVersionName}"
+    PUBLISH_ARTIFACT_ID = "ouisync-omni"
+}
+
+tasks.withType(Sign).configureEach {
+    onlyIf { rootProject.gradle.startParameter.taskNames.contains('lib:publishToSonatype') }
+}
+
+apply from: "${rootProject.projectDir}/build-scripts/publish-module.gradle"

--- a/bindings/kotlin/local.properties.sample
+++ b/bindings/kotlin/local.properties.sample
@@ -1,0 +1,2 @@
+versionName=0.7.2
+useLocalLib=true

--- a/bindings/kotlin/settings.gradle
+++ b/bindings/kotlin/settings.gradle
@@ -2,4 +2,5 @@ rootProject.name = 'ouisync-kotlin'
 
 include 'lib'
 include 'example'
+include 'build-scripts'
 


### PR DESCRIPTION
This PR allows us to publish the AAR generated for the kotlin bindings to our public Sonatype maven repository. After assembling the AAR with `./gradlew lib:assembleRelease`, it is possible to publish the AAR with the following command,
```
OSSRH_USERNAME="$ossrh-username" \
OSSRH_PASSWORD="$ossrh-password" \
SIGNING_PASSWORD="$signing-password" \
SIGNING_KEY_ID=$signing-key-id \
SIGNING_KEY="$signing-key" \
SONATYPE_STAGING_PROFILE_ID=$sonatype-profile-id \
./gradlew lib:publishToSonatype
```
where the credentials, keys, and ids should be retrieved from the password store.

Once the repository is closed, you can test the AAR with the example app by setting the `useLocalLib` property (in the `local.properties` file) to `false` and adding the following lines to the top-level `build.gradle` in the `allprojects { repositories {` block, 

```
maven {
    url "https://s01.oss.sonatype.org/content/repositories/ieequalitouinet-1196"
}
```
where the url matches the closed test repo (note: that link shown above currently contains a test AAR).

@madadam @inetic @J-Pabon Please review and make any changes you think are needed prior to merging.

Thanks!