### PR TITLE
Add reset support to channeled sessions

### DIFF
--- a/bindings/dart/lib/ouisync.dart
+++ b/bindings/dart/lib/ouisync.dart
@@ -92,8 +92,8 @@ class Session {
   // native code.
   // [channelName] is the name of the MethodChannel to be used, equally named channel
   // must be created and set up to listen to the commands in the native code.
-  static Future<Session> createChanneled(String channelName) async {
-    final client = ChannelClient(channelName);
+  static Future<Session> createChanneled(String channelName, void Function()? onConnectionReset) async {
+    final client = ChannelClient(channelName, onConnectionReset);
     await client.initialize();
     return Session._(client);
   }


### PR DESCRIPTION
Channeled sessions communicate with the library via some host-provided IPC link that can fail for any number of reasons, though usually because the remote peer is shutting down. This updates the dart-to-native protocol to allow the host to detect and update the user interface when this happens.