### PR TITLE
Add reset support to channeled sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 /target
 proptest-regressions
 Cargo.lock

--- a/bindings/dart/lib/client.dart
+++ b/bindings/dart/lib/client.dart
@@ -38,6 +38,11 @@ class Subscriptions {
       // error.
     }
   }
+
+  void close() {
+    _sinks.values.forEach((sink) => sink.close());
+    _sinks.clear();
+  }
 }
 
 class Subscription {

--- a/bindings/dart/lib/errors.dart
+++ b/bindings/dart/lib/errors.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/services.dart';
+
+
+/* Thrown when a native call could not be completed because the
+flutter application host is itself shutting down. Usually when
+this happens, the dart vm is probably shutting down as well.
+
+Corresponds to error code OS00 */
+class HostShutdown extends Error {}
+
+/* Thrown when the application host encountered an unexpected error
+while processing the request. This differs from BindingsOutOfDate
+by the host explicitly notifying us of this situation.
+
+Corresponds to error code OS01 */
+class InternalError extends Error {}
+
+/* Thrown when the application host was unable to open a channel
+to the rust library. The usual way to handle this is to show it
+to the user and try to create a new session at a later time.
+
+Corresponds to error code OS02 */
+class ProviderUnavailable implements Exception {}
+
+/* Thrown when the application host was unable to collect the
+arguments of a method call. This likely means that an argument
+was not provided when it was required by a native call.
+
+Corresponds to error code OS03 */
+class HostArgumentError extends ArgumentError {}
+
+/* Thrown for every request made after the session has been closed. 
+
+Corresponds to error code OS04 */
+class SessionClosed extends StateError {
+  SessionClosed() : super('Session closed');
+}
+
+/* Thrown if the application host attempts to communicate with the
+library host (sometimes called file provider extension) over an
+unsupported channel. Currently this is specific to macOS and there
+is no reasonable way to handle it other than craashing.
+
+Corresponds to error code OS05 */
+class HostLinkingError extends UnsupportedError {
+  HostLinkingError(super.message);
+}
+
+/* Thrown if the bindings attempt to invoke a method that is not
+exported by the application host. De facto equivalent with
+NoSuchMethodError, but presently without the stack information.
+
+Corresponds to error code OS06 */
+class MethodNotExported extends UnsupportedError {
+  MethodNotExported(super.message);
+}
+
+/* Thrown when an error was thrown with an associated error code
+that was not recognized by this version of the package. While you
+can inspect the error code and message manually, it's probably
+better to update the bindings or report this.
+
+Corresponds to any other error code not described here */
+class BindingsOutOfDate extends UnimplementedError {
+  final String code;
+  BindingsOutOfDate(this.code, super.message);
+}
+
+Object mapError(PlatformException err) => switch (err.code) {
+  'OS00' => HostShutdown(),
+  'OS01' => InternalError(),
+  'OS02' => ProviderUnavailable(),
+  'OS03' => HostArgumentError(),
+  'OS04' => SessionClosed(),
+  'OS06' => HostLinkingError(err.message!),
+  'OS07' => MethodNotExported(err.message!),
+  _ => BindingsOutOfDate(err.code, err.message)
+};

--- a/bindings/dart/lib/internal/channel_client.dart
+++ b/bindings/dart/lib/internal/channel_client.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/services.dart';
 import '../client.dart';
 import 'message_matcher.dart';
@@ -5,15 +7,12 @@ import 'message_matcher.dart';
 class ChannelClient extends Client {
   final MethodChannel _channel;
   final _messageMatcher = MessageMatcher();
+  late final Future<void> initialized;
+  final void Function()? _onClose;
 
-  ChannelClient(String channelName) : _channel = MethodChannel(channelName) {
+  ChannelClient(String channelName, [this._onClose]): _channel = MethodChannel(channelName) {
     _channel.setMethodCallHandler(_handleMethodCall);
-  }
-
-  Future<void> initialize() async {
-    await _messageMatcher.sendAndAwaitResponse("", {}, (Uint8List message) async {
-      await _channel.invokeMethod("initialize", message);
-    });
+    initialized = _channel.invokeMethod("initialize");
   }
 
   @override
@@ -27,12 +26,23 @@ class ChannelClient extends Client {
   Future<void> close() async {
     _channel.setMethodCallHandler(null);
     _messageMatcher.close();
+    _onClose?.call();
   }
 
   Future<dynamic> _handleMethodCall(MethodCall call) async {
-    final args = (call.arguments as List<Object?>).cast<int>();
-    _messageMatcher.handleResponse(Uint8List.fromList(args));
-    return null;
+    switch (call.method) {
+      case "reset":
+        print("😡 Connection to Ouisync has been ${call.arguments as String}");
+        unawaited(close()); // this is not actually async anymore
+        break;
+      case "response":
+        final args = (call.arguments as List<Object?>).cast<int>();
+        _messageMatcher.handleResponse(Uint8List.fromList(args));
+        break;
+      default:
+        print("🌵 Received an unrecognized method call from Native: ${call.method}");
+        break;
+    }
   }
 
   @override

--- a/bindings/dart/lib/internal/message_matcher.dart
+++ b/bindings/dart/lib/internal/message_matcher.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:msgpack_dart/msgpack_dart.dart';
 
 import '../client.dart';
+import '../errors.dart';
 import '../ouisync.dart' show Error;
 import '../bindings.dart' show ErrorCode;
 
@@ -46,7 +47,7 @@ class MessageMatcher {
           .takeBytes();
         
       if (_isClosed) {
-        throw StateError('session has been closed');
+        throw SessionClosed();
       }
 
       await send(message);
@@ -101,7 +102,7 @@ class MessageMatcher {
   void close() {
     _isClosed = true;
     _subscriptions.close();
-    final error = PlatformException(code: "OS04", message: "Library connection reset");
+    final error = SessionClosed();
     _responses.values.forEach((i) => i.completeError(error));
     _responses.clear();
   }

--- a/bindings/dart/lib/internal/message_matcher.dart
+++ b/bindings/dart/lib/internal/message_matcher.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:typed_data';
 import 'dart:collection';
+import 'package:flutter/services.dart';
 import 'package:msgpack_dart/msgpack_dart.dart';
 
 import '../client.dart';
@@ -99,7 +100,10 @@ class MessageMatcher {
 
   void close() {
     _isClosed = true;
-    // TODO: Complete completers with an error
+    _subscriptions.close();
+    final error = PlatformException(code: "OS04", message: "Library connection reset");
+    _responses.values.forEach((i) => i.completeError(error));
+    _responses.clear();
   }
 
   void _handleResponseSuccess(Completer<Object?> completer, Object? payload) {

--- a/bindings/dart/lib/ouisync.dart
+++ b/bindings/dart/lib/ouisync.dart
@@ -92,9 +92,9 @@ class Session {
   // native code.
   // [channelName] is the name of the MethodChannel to be used, equally named channel
   // must be created and set up to listen to the commands in the native code.
-  static Future<Session> createChanneled(String channelName) async {
-    final client = ChannelClient(channelName);
-    await client.initialize();
+  static Future<Session> createChanneled(String channelName, [void Function()? onClose]) async {
+    final client = ChannelClient(channelName, onClose);
+    await client.initialized;
     return Session._(client);
   }
 


### PR DESCRIPTION
Channeled sessions communicate with the library via some host-provided IPC link that can fail for any number of reasons, though usually because the remote peer is shutting down. This updates the dart-to-native protocol to allow the host to detect and update the user interface when this happens.