### PR TITLE
Add initial CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,123 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
+## Unreleased
+
+- See changes [v0.8.10...HEAD](https://github.com/equalitie/ouisync/compare/v0.8.10...HEAD)
+
+# Appendix A: Git tags reference
+
+This section lists older tags in the repository as a reference to the changes
+released before adhering to consistent release note format. A link to the
+comparison between the previous version and the listed version is provided to
+give some idea of the changes included in the version. 
+
+## [v0.8.10](https://github.com/equalitie/ouisync/releases/tag/v0.8.10) - 2024-11-06
+
+- See changes [v0.8.9...v0.8.10](https://github.com/equalitie/ouisync/compare/v0.8.9...v0.8.10)
+
+## [v0.8.9](https://github.com/equalitie/ouisync/releases/tag/v0.8.9) - 2024-11-04
+
+- See changes [v0.8.8...v0.8.9](https://github.com/equalitie/ouisync/compare/v0.8.8...v0.8.9)
+
+## [v0.8.8](https://github.com/equalitie/ouisync/releases/tag/v0.8.8) - 2024-07-05
+
+- See changes [v0.8.7...v0.8.8](https://github.com/equalitie/ouisync/compare/v0.8.7...v0.8.8)
+
+## [v0.8.7](https://github.com/equalitie/ouisync/releases/tag/v0.8.7) - 2024-06-19
+
+- See changes [v0.8.6...v0.8.7](https://github.com/equalitie/ouisync/compare/v0.8.6...v0.8.7)
+
+## [v0.8.6](https://github.com/equalitie/ouisync/releases/tag/v0.8.6) - 2024-06-18
+
+- See changes [v0.8.5...v0.8.6](https://github.com/equalitie/ouisync/compare/v0.8.5...v0.8.6)
+
+## [v0.8.5](https://github.com/equalitie/ouisync/releases/tag/v0.8.5) - 2024-06-13
+
+- See changes [v0.8.4...v0.8.5](https://github.com/equalitie/ouisync/compare/v0.8.4...v0.8.5)
+
+## [v0.8.4](https://github.com/equalitie/ouisync/releases/tag/v0.8.4) - 2024-06-13
+
+- See changes [v0.8.3...v0.8.4](https://github.com/equalitie/ouisync/compare/v0.8.3...v0.8.4)
+
+## [v0.8.3](https://github.com/equalitie/ouisync/releases/tag/v0.8.3) - 2024-05-28
+
+- See changes [v0.8.2...v0.8.3](https://github.com/equalitie/ouisync/compare/v0.8.2...v0.8.3)
+
+## [v0.8.2](https://github.com/equalitie/ouisync/releases/tag/v0.8.2) - 2024-04-03
+
+- See changes [v0.8.1...v0.8.2](https://github.com/equalitie/ouisync/compare/v0.8.1...v0.8.2)
+
+## [v0.8.1](https://github.com/equalitie/ouisync/releases/tag/v0.8.1) - 2024-03-15
+
+- See changes [v0.8.0...v0.8.1](https://github.com/equalitie/ouisync/compare/v0.8.0...v0.8.1)
+
+## [v0.8.0](https://github.com/equalitie/ouisync/releases/tag/v0.8.0) - 2024-03-12
+
+- See changes [v0.7.4...v0.8.0](https://github.com/equalitie/ouisync/compare/v0.7.4...v0.8.0)
+
+## [v0.7.4](https://github.com/equalitie/ouisync/releases/tag/v0.7.4) - 2024-01-25
+
+- See changes [v0.7.3...v0.7.4](https://github.com/equalitie/ouisync/compare/v0.7.3...v0.7.4)
+
+## [v0.7.3](https://github.com/equalitie/ouisync/releases/tag/v0.7.3) - 2024-01-18
+
+- See changes [v0.7.2...v0.7.3](https://github.com/equalitie/ouisync/compare/v0.7.2...v0.7.3)
+
+## [v0.7.2](https://github.com/equalitie/ouisync/releases/tag/v0.7.2) - 2023-12-05
+
+- See changes [v0.7.1...v0.7.2](https://github.com/equalitie/ouisync/compare/v0.7.1...v0.7.2)
+
+## [v0.7.1](https://github.com/equalitie/ouisync/releases/tag/v0.7.1) - 2023-12-05
+
+- See changes [v0.7.0...v0.7.1](https://github.com/equalitie/ouisync/compare/v0.7.0...v0.7.1)
+
+## [v0.7.0](https://github.com/equalitie/ouisync/releases/tag/v0.7.0) - 2023-12-05
+
+- See changes [v0.6.1...v0.7.0](https://github.com/equalitie/ouisync/compare/v0.6.1...v0.7.0)
+
+## [v0.6.1](https://github.com/equalitie/ouisync/releases/tag/v0.6.1) - 2023-11-02
+
+- See changes [v0.6.0...v0.6.1](https://github.com/equalitie/ouisync/compare/v0.6.0...v0.6.1)
+
+## [v0.6.0](https://github.com/equalitie/ouisync/releases/tag/v0.6.0) - 2023-11-02
+
+- First tagged release
+- See changes [v0.5.2...v0.6.1](https://github.com/equalitie/ouisync/compare/fc501bd...v0.6.1)
+
+## [v0.5.2](https://github.com/equalitie/ouisync/commit/fc501bd) - 2023-06-27
+
+- See changes [v0.5.1...v0.5.2](https://github.com/equalitie/ouisync/compare/c040ba2...fc501bd)
+
+## [v0.5.1](https://github.com/equalitie/ouisync/commit/c040ba2) - 2022-12-21
+
+- See changes [v0.5.0...v0.5.1](https://github.com/equalitie/ouisync/compare/45d762e...c040ba2)
+
+## [v0.5.0](https://github.com/equalitie/ouisync/commit/45d762e) - 2022-11-23
+
+- See changes [v0.5.0...v0.5.1](https://github.com/equalitie/ouisync/compare/c5b90b5...45d762e)
+
+## [v0.4.1](https://github.com/equalitie/ouisync/commit/c5b90b5) - 2022-11-22
+
+- See changes [v0.4.0...v0.4.1](https://github.com/equalitie/ouisync/compare/6ecf303...c5b90b5)
+
+## [v0.4.0](https://github.com/equalitie/ouisync/commit/6ecf303) - 2022-10-18
+
+- See changes [v0.3.1...v0.4.0](https://github.com/equalitie/ouisync/compare/0210198...6ecf303)
+
+## [v0.3.1](https://github.com/equalitie/ouisync/commit/0210198) - 2022-10-05
+
+- See changes [v0.2.0...v0.3.1](https://github.com/equalitie/ouisync/compare/4d5a538...0210198)
+
+## [v0.2.0](https://github.com/equalitie/ouisync/commit/4d5a538) - 2022-10-05
+
+- See changes [653675e...v0.2.0](https://github.com/equalitie/ouisync/compare/653675e...4d5a538)
+
+## [653675e](https://github.com/equalitie/ouisync/commit/653675e) - 2020-09-16
+
+- Initial commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- See changes [v0.8.10...HEAD](https://github.com/equalitie/ouisync/compare/v0.8.10...HEAD)
+- See changes [v0.8.11...HEAD](https://github.com/equalitie/ouisync/compare/v0.8.11...HEAD)
 
 # Appendix A: Git tags reference
 
@@ -16,6 +16,10 @@ This section lists older tags in the repository as a reference to the changes
 released before adhering to consistent release note format. A link to the
 comparison between the previous version and the listed version is provided to
 give some idea of the changes included in the version. 
+
+## [v0.8.11](https://github.com/equalitie/ouisync/releases/tag/v0.8.11) - 2025-01-27
+
+- See changes [v0.8.10...v0.8.11](https://github.com/equalitie/ouisync/compare/v0.8.10...v0.8.11)
 
 ## [v0.8.10](https://github.com/equalitie/ouisync/releases/tag/v0.8.10) - 2024-11-06
 


### PR DESCRIPTION
@inetic @madadam
This PR adds a CHANGELOG.md. I have started it off by listing the historical tagged releases. Additionally, through some digging, I added a handful of commits where the version number was bumped but no tag made, for v0.2.0 through v0.6.0. Earlier than that, things get a little messy, so I just provided the hash of the initial commit.

Going forward, changes should be added to the CHANGELOG following the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format, see [Ouinet's CHANGELOG](https://gitlab.com/equalitie/ouinet/-/blob/main/CHANGELOG.md) as a reference also. Ideally, changes should logged when they are made (or merged to master) or, at latest, when the release is tagged.

If you are able to log what has changed since 0.8.10, that would be good to go in the "unreleased" section of the CHANGELOG. Or, I noticed that you already bumped to 0.8.11 though never tagged it, we could tag that version and add it to the historical releases. Then we could start fresh for the v0.8.12 release.