### PR TITLE
Clarify how the seed is used to create the write key

### DIFF
--- a/doc/paper.md
+++ b/doc/paper.md
@@ -228,7 +228,7 @@ tokens**. These sections describes both in detail.
 The access secrets are computed as follows:
 
 1. First a 256-bit number (called "Seed") is generated with a cryptographically secure RNG.
-2. This number is then interpreted as a ED25519 signing private key which is called the **Write key**.
+2. This number is then used to derive a ED25519 signing private key which is called the **Write key**.
 3. The corresponding public key is called the **Repository ID**.
 4. Finally the salted hash of the seed, interpreted as a symmetric secret key is called the **Read key**.
 


### PR DESCRIPTION
I tripped over the word _interpret_ here on step 2. Since the private key is a scalar i _guess_ you _could_ use it directly but that would skip the SHA512 hashing and clamping that is given in [the key generation section of RFC8032](https://www.rfc-editor.org/rfc/rfc8032#section-5.1.5). 

I think using the word _derive_ instead makes it clearer that this is more involved and less ambigous with the use of the word on step 4.