### PR TITLE
Fix iOS build 

### DIFF
--- a/fs_util/Cargo.toml
+++ b/fs_util/Cargo.toml
@@ -13,7 +13,7 @@ tokio        = { workspace = true, features = ["fs", "io-util", "rt", "sync"] }
 tokio-stream = { workspace = true }
 walkdir      = "2.5.0"
 
-[target.'cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "android", target_os = "macos", target_os = "ios"))'.dependencies]
 libc         = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/fs_util/src/safe_move.rs
+++ b/fs_util/src/safe_move.rs
@@ -143,7 +143,7 @@ fn blocking_rename_no_replace_atomic(src: &Path, dst: &Path) -> io::Result<()> {
     }
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 fn blocking_rename_no_replace_atomic(src: &Path, dst: &Path) -> io::Result<()> {
     use std::ffi::CString;
 

--- a/service/src/logger/mod.rs
+++ b/service/src/logger/mod.rs
@@ -5,11 +5,9 @@ mod format;
 #[path = "android.rs"]
 mod output;
 
-#[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
+#[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos", target_os = "ios"))]
 #[path = "stdout.rs"]
 mod output;
-
-// TODO: ios
 
 pub use color::{LogColor, ParseLogColorError};
 pub use format::{LogFormat, ParseLogFormatError};


### PR DESCRIPTION
- fs_util/Cargo.toml: add ios to the libc target cfg so the crate links correctly when cross-compiling for iOS targets
- fs_util/src/safe_move.rs: extend blocking_rename_no_replace_atomic cfg to any(macos, ios) — renamex_np has been available on iOS 10+
- service/src/logger/mod.rs: route ios through stdout.rs, resolving the pre-existing TODO comment